### PR TITLE
Makefile: Use $(DESTDIR) in install-data-hook

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,4 +3,4 @@ fweelindir = $(datadir)/fweelin
 fweelin_DATA = *.txt *.xml basic.sf2 vera.ttf verabd.ttf gdb-stackdump-cmds
 
 install-data-hook:
-	sed -ie "s/<freewheeling version=\"_FWEELIN_VERSION_\">/<freewheeling version=\"${VERSION}\">/" $(fweelindir)/fweelin.xml
+	sed -ie "s/<freewheeling version=\"_FWEELIN_VERSION_\">/<freewheeling version=\"${VERSION}\">/" $(DESTDIR)$(fweelindir)/fweelin.xml


### PR DESCRIPTION
Lack of it broke distribution package building.