### PR TITLE
Fix 'double free' when pressing 'u' to delete a loop

### DIFF
--- a/src/fweelin_block.cc
+++ b/src/fweelin_block.cc
@@ -1000,7 +1000,10 @@ void AudioBlock::DeleteChain() {
     BlockExtendedData *curxt = cur->xt;
     while (curxt != 0) {
       BlockExtendedData *tmpxt = curxt->next;
-      delete curxt;
+      if (curxt->GetType() == T_BED_ExtraChannel)
+        ((BED_ExtraChannel *)curxt)->RTDelete();
+      else
+        delete curxt;
       curxt = tmpxt;
     }
 

--- a/src/fweelin_mem.h
+++ b/src/fweelin_mem.h
@@ -132,12 +132,10 @@ class Preallocated {
     exit(1);
   };
   void operator delete(void *d) {
-    //printf("ERROR: Preallocated type can not be deleted directly\n");
-    //exit(1);
-
-    // We used to give an error message-
-    // now we pass this delete on to RTDelete
-    ((Preallocated *) d)->RTDelete();
+    // cannot pass to RTDelete as this would end with two delete executed
+    // and destructor called twice
+    printf("ERROR: Preallocated type can not be deleted directly\n");
+    exit(1);
   }
 
   // Realtime-safe function to get a new instance of this class


### PR DESCRIPTION
Do not use 'delete' operator on Preallocated objects

While overloading delete for Preallocated classes seems like a smart
trick, it might cause problems, as delete operator would be used twice
(once explicitly and once in the RTDelete() internals), which would
execute class destructor twice which could cause double free errors.

This fixes 'glibc-detected double free' crash when deleting a loop on my
system.