### PR TITLE
Use jack_client_open() instead of jack_client_new()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_CHECK_LIB([asound], [main], ,
   [AC_MSG_ERROR(AUDIO: You need ALSA installed (libasound2-dev).
 		http://www.alsa-project.org/)])
 
-AC_CHECK_LIB([jack], [jack_client_new], , 
+AC_CHECK_LIB([jack], [jack_client_open], , 
   [AC_MSG_ERROR(AUDIO: You need JACK audio library (libjack-dev) installed.
 		http://jackit.sourceforge.net/)])
 

--- a/src/fweelin_audioio.cc
+++ b/src/fweelin_audioio.cc
@@ -274,7 +274,8 @@ int AudioIO::open () {
   // **** AUDIO startup
   
   // Try to become a client of the JACK server
-  if ((client = jack_client_new ("FreeWheeling")) == 0) {
+  client = jack_client_open("FreeWheeling", JackNoStartServer, NULL);
+  if (!client) {
     fprintf (stderr, "AUDIO: ERROR: Jack server not running!\n");
     return 1;
   }


### PR DESCRIPTION
jack_client_new() is deprecated and only extremely old jack releases did
not have jack_client_open()

Prevents warning:
> fweelin_audioio.cc:277:17: warning: 'jack_client_t* jack_client_new(const char*)' is deprecated [-Wdeprecated-declarations]