### PR TITLE
Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Ref:
+# https://docs.travis-ci.com/user/job-lifecycle/
+# https://docs.travis-ci.com/user/languages/cpp/
+# https://docs.travis-ci.com/user/installing-dependencies
+# https://docs.travis-ci.com/user/customizing-the-build/
+
+os: linux
+dist: bionic
+language: cpp
+compiler: gcc
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y build-dep freewheeling
+  # build-dep is not sufficient, we need to explicitly install liblo-dev
+  - sudo apt-get -y install liblo-dev
+
+script:
+  - autoreconf -if
+  - ./configure
+  - make
+  - sudo make install
+  - make installcheck


### PR DESCRIPTION
Hello,

I recently discovered travis-ci.  I have no affiliation, but I find it very useful for open source project.

In this PR, I created the travis-ci config (.travis.yml) and modified slightly the automake required version.  For some strange reason, the version of automake that gets installed on the bionic ubuntu VM is 1.15 instead of 1.16.  I tried it and it works.  Let me know if this can be an issue.

You can have a look at the result here: https://travis-ci.org/github/mathieugouin/freewheeling

Once you merge the PR, you would simply need to sign in to travis-ci.org with github.com, then enable the build for freewheeling.

Let me know if I can help more.

Thanks